### PR TITLE
Fix bus location by correcting latitude/longitude scaling factor

### DIFF
--- a/TDOT_IVB/templates/index.html
+++ b/TDOT_IVB/templates/index.html
@@ -183,8 +183,8 @@
             smartinfo.forEach(function(bus){
                 if(bus.latitude && bus.longitude && bus.latitude != 648000002 && bus.longitude != 648000002){
                     // Skalieren der Koordinaten, falls notwendig
-                    var lat = bus.latitude / 10000000;
-                    var lon = bus.longitude / 10000000;
+                    var lat = bus.latitude / 3600000;
+                    var lon = bus.longitude / 3600000;
                     L.marker([lat, lon], {
                         rotationAngle: bus.bearing
                     }).addTo(map)


### PR DESCRIPTION
Thanks for this project, was playing with the API myself recently and could not make sense of the latitude/longitude values.
Looking through GitHub, I found another repository doing something similar for the public transport in Bern.
The correct scaling factor for longitude/latitude values seems to be 3_600_000.

I found this value in this repository:
https://github.com/CPlusPlus17/HoneyBadger-BERNMOBIL/blob/94e018fa0dd32863e5462c09106a9853061dcc6c/03_Backend/Bernmobil/Services/BernmobilService.cs#L86

The original protobuf definitions including the MAX/MIN and other special values can be found here:
https://github.com/CPlusPlus17/HoneyBadger-BERNMOBIL/blob/94e018fa0dd32863e5462c09106a9853061dcc6c/03_Backend/Bernmobil/Protos/StopTdi.proto#L76

So in my understanding, this should be the correct check for valid values:
-324000000 <= latitude <= 324000000
-648000000 <= longitude <= 648000000
0 <= bearing <= 359

![image](https://github.com/user-attachments/assets/5934ff24-e4c8-402f-b0cf-72145210b5c1)
